### PR TITLE
feat: @tidyjs-ignore-sort directive + auto-skip numeric enums

### DIFF
--- a/src/destructuring-sorter.ts
+++ b/src/destructuring-sorter.ts
@@ -78,6 +78,40 @@ function isRestNode(node: AST.ASTNode): boolean {
     return node.type === 'RestElement' || node.type === 'SpreadElement' || node.type === 'JSXSpreadAttribute';
 }
 
+/**
+ * Check if the line immediately before a node's containing statement has `// @tidyjs-ignore-sort`.
+ * First walks back to the start of the line containing nodeRange[0],
+ * then checks the line above that.
+ */
+function hasIgnoreSortComment(sourceText: string, nodeRange: [number, number]): boolean {
+    // Find the start of the line containing the node
+    let lineStart = nodeRange[0];
+    while (lineStart > 0 && sourceText[lineStart - 1] !== '\n') {
+        lineStart--;
+    }
+    // Now find the previous line (the one above)
+    if (lineStart === 0) {return false;} // node is on the first line
+    const prevLineEnd = lineStart - 1; // points to the \n before current line
+    let prevLineStart = prevLineEnd;
+    while (prevLineStart > 0 && sourceText[prevLineStart - 1] !== '\n') {
+        prevLineStart--;
+    }
+    const prevLine = sourceText.slice(prevLineStart, prevLineEnd);
+    return /^\s*\/\/\s*@tidyjs-ignore-sort\s*$/.test(prevLine);
+}
+
+/**
+ * Check if all members of an enum have explicit numeric initializers.
+ * When they do, the order is intentional (semantic) and should not be sorted.
+ */
+function hasAllNumericInitializers(members: AST.ASTNode[]): boolean {
+    if (members.length === 0) {return false;}
+    return members.every(m => {
+        const member = m as AST.TSEnumMember;
+        return member.initializer !== undefined && member.initializer !== null && typeof member.initializer.value === 'number';
+    });
+}
+
 function isMultiline(sourceText: string, range: [number, number]): boolean {
     const text = sourceText.slice(range[0], range[1]);
     return text.includes('\n');
@@ -163,15 +197,18 @@ function findSortablePatterns(
         if (config?.format?.sortEnumMembers && node.type === 'TSEnumDeclaration' && node.range) {
             const enumNode = node as AST.TSEnumDeclaration;
             const members = enumNode.body?.members ?? enumNode.members;
-            if (members && members.length >= 2) {
-                const braceRange = findBraceRange(node.range as [number, number], sourceText);
-                if (braceRange && isMultiline(sourceText, braceRange) && !hasInternalComments(sourceText, braceRange)) {
-                    const props = extractProperties(
-                        members as AST.ASTNode[],
-                        sourceText
-                    );
-                    if (props && props.length >= 2) {
-                        patterns.push({ kind: 'enumBody', range: braceRange, properties: props });
+            if (members && members.length >= 2 && !hasAllNumericInitializers(members as AST.ASTNode[])) {
+                const nodeRange = node.range as [number, number];
+                if (!hasIgnoreSortComment(sourceText, nodeRange)) {
+                    const braceRange = findBraceRange(nodeRange, sourceText);
+                    if (braceRange && isMultiline(sourceText, braceRange) && !hasInternalComments(sourceText, braceRange)) {
+                        const props = extractProperties(
+                            members as AST.ASTNode[],
+                            sourceText
+                        );
+                        if (props && props.length >= 2) {
+                            patterns.push({ kind: 'enumBody', range: braceRange, properties: props });
+                        }
                     }
                 }
             }
@@ -179,7 +216,7 @@ function findSortablePatterns(
 
         if (config?.format?.sortExports && node.type === 'ExportNamedDeclaration' && node.range) {
             const exportNode = node as AST.ExportNamedDeclaration;
-            if (exportNode.specifiers.length >= 2) {
+            if (exportNode.specifiers.length >= 2 && !hasIgnoreSortComment(sourceText, node.range as [number, number])) {
                 const braceRange = findBraceRange(node.range as [number, number], sourceText);
                 if (braceRange && isMultiline(sourceText, braceRange) && !hasInternalComments(sourceText, braceRange)) {
                     const props = extractProperties(
@@ -193,7 +230,7 @@ function findSortablePatterns(
             }
         }
 
-        if (config?.format?.sortClassProperties && node.type === 'ClassBody' && node.range) {
+        if (config?.format?.sortClassProperties && node.type === 'ClassBody' && node.range && !hasIgnoreSortComment(sourceText, node.range as [number, number])) {
             const classBody = node as AST.ClassBody;
             // Find contiguous runs of PropertyDefinition nodes
             let currentRun: AST.PropertyDefinition[] = [];
@@ -230,7 +267,7 @@ function findSortablePatterns(
             flushRun();
         }
 
-        if (config?.format?.sortTypeMembers && node.type === 'TSInterfaceBody' && node.range) {
+        if (config?.format?.sortTypeMembers && node.type === 'TSInterfaceBody' && node.range && !hasIgnoreSortComment(sourceText, node.range as [number, number])) {
             const range = node.range as [number, number];
             if (isMultiline(sourceText, range) && !hasInternalComments(sourceText, range)) {
                 const props = extractProperties(
@@ -243,7 +280,7 @@ function findSortablePatterns(
             }
         }
 
-        if (config?.format?.sortTypeMembers && node.type === 'TSTypeLiteral' && node.range) {
+        if (config?.format?.sortTypeMembers && node.type === 'TSTypeLiteral' && node.range && !hasIgnoreSortComment(sourceText, node.range as [number, number])) {
             const range = node.range as [number, number];
             if (isMultiline(sourceText, range) && !hasInternalComments(sourceText, range)) {
                 const props = extractProperties(
@@ -294,7 +331,7 @@ function findSortablePatternsInRange(
 
         if (node.type === 'ObjectPattern' && node.range) {
             const range = node.range as [number, number];
-            if (rangesOverlap(range, selRange) && isMultiline(sourceText, range)) {
+            if (rangesOverlap(range, selRange) && isMultiline(sourceText, range) && !hasIgnoreSortComment(sourceText, range)) {
                 const props = extractProperties(
                     node.properties as AST.ASTNode[],
                     sourceText
@@ -307,7 +344,7 @@ function findSortablePatternsInRange(
 
         if (node.type === 'ObjectExpression' && node.range) {
             const range = node.range as [number, number];
-            if (rangesOverlap(range, selRange) && isMultiline(sourceText, range)) {
+            if (rangesOverlap(range, selRange) && isMultiline(sourceText, range) && !hasIgnoreSortComment(sourceText, range)) {
                 const props = extractProperties(
                     node.properties as AST.ASTNode[],
                     sourceText
@@ -320,7 +357,7 @@ function findSortablePatternsInRange(
 
         if (node.type === 'TSInterfaceBody' && node.range) {
             const range = node.range as [number, number];
-            if (rangesOverlap(range, selRange) && isMultiline(sourceText, range)) {
+            if (rangesOverlap(range, selRange) && isMultiline(sourceText, range) && !hasIgnoreSortComment(sourceText, range)) {
                 const props = extractProperties(
                     node.body as AST.ASTNode[],
                     sourceText
@@ -333,7 +370,7 @@ function findSortablePatternsInRange(
 
         if (node.type === 'TSTypeLiteral' && node.range) {
             const range = node.range as [number, number];
-            if (rangesOverlap(range, selRange) && isMultiline(sourceText, range)) {
+            if (rangesOverlap(range, selRange) && isMultiline(sourceText, range) && !hasIgnoreSortComment(sourceText, range)) {
                 const props = extractProperties(
                     node.members as AST.ASTNode[],
                     sourceText
@@ -352,7 +389,7 @@ function findSortablePatternsInRange(
                 const lastRange = attrs[attrs.length - 1].range as [number, number] | undefined;
                 if (firstRange && lastRange) {
                     const range: [number, number] = [firstRange[0], lastRange[1]];
-                    if (rangesOverlap(range, selRange) && isMultiline(sourceText, range)) {
+                    if (rangesOverlap(range, selRange) && isMultiline(sourceText, range) && !hasIgnoreSortComment(sourceText, node.range as [number, number])) {
                         const props = extractProperties(attrs, sourceText);
                         if (props && props.length >= 2) {
                             patterns.push({ kind: 'jsxAttributes', range, properties: props });

--- a/src/types/ast.ts
+++ b/src/types/ast.ts
@@ -63,6 +63,7 @@ export interface TSEnumDeclaration extends ASTNode {
 export interface TSEnumMember extends ASTNode {
     type: 'TSEnumMember';
     id: { type: string; name?: string; value?: unknown };
+    initializer?: { type: string; value?: unknown; raw?: string } | null;
 }
 
 export interface TSPropertySignature extends ASTNode {

--- a/test/parser/destructuring-sorter.test.ts
+++ b/test/parser/destructuring-sorter.test.ts
@@ -463,18 +463,28 @@ describe('sortEnumMembers', () => {
         expect(sortCodePatterns(input, enumConfig)).toBe(expected);
     });
 
-    it('should handle enums with string literal keys', () => {
+    it('should handle enums with string literal keys and string values', () => {
+        const input = `enum Codes {
+    'long-code' = 'lc',
+    'ab' = 'a',
+}`;
+
+        const expected = `enum Codes {
+    'ab' = 'a',
+    'long-code' = 'lc',
+}`;
+
+        expect(sortCodePatterns(input, enumConfig)).toBe(expected);
+    });
+
+    it('should skip enums with string literal keys but numeric values', () => {
         const input = `enum Codes {
     'long-code' = 1,
     'ab' = 2,
 }`;
 
-        const expected = `enum Codes {
-    'ab' = 2,
-    'long-code' = 1,
-}`;
-
-        expect(sortCodePatterns(input, enumConfig)).toBe(expected);
+        // Numeric initializers → order is intentional
+        expect(sortCodePatterns(input, enumConfig)).toBe(input);
     });
 
     it('should preserve trailing comma behavior', () => {
@@ -957,5 +967,196 @@ describe('sortTypeMembers', () => {
 }`;
 
         expect(sortCodePatterns(input, typeMembersConfig)).toBe(expected);
+    });
+});
+
+describe('@tidyjs-ignore-sort directive', () => {
+    describe('automatic pipeline', () => {
+        it('should skip enum when preceded by @tidyjs-ignore-sort', () => {
+            const input = `// @tidyjs-ignore-sort
+enum Status {
+    InProgress = 'in_progress',
+    OK = 'ok',
+    Error = 'error',
+}`;
+
+            expect(sortCodePatterns(input, enumConfig)).toBe(input);
+        });
+
+        it('should skip exports when preceded by @tidyjs-ignore-sort', () => {
+            const input = `// @tidyjs-ignore-sort
+export {
+    useCallback,
+    useState,
+    FC,
+} from 'react';`;
+
+            expect(sortCodePatterns(input, exportConfig)).toBe(input);
+        });
+
+        it('should skip class when preceded by @tidyjs-ignore-sort', () => {
+            const input = `// @tidyjs-ignore-sort
+class User {
+    telephone: string;
+    id: string;
+    nom: string;
+}`;
+
+            expect(sortCodePatterns(input, classConfig)).toBe(input);
+        });
+
+        it('should skip interface when preceded by @tidyjs-ignore-sort', () => {
+            const input = `// @tidyjs-ignore-sort
+interface Props {
+    className: string;
+    datatestIdAttribute: string;
+    datatestId: string;
+}`;
+
+            expect(sortCodePatterns(input, typeMembersConfig)).toBe(input);
+        });
+
+        it('should skip type literal when preceded by @tidyjs-ignore-sort', () => {
+            const input = `// @tidyjs-ignore-sort
+type Props = {
+    className: string;
+    datatestIdAttribute: string;
+    datatestId: string;
+};`;
+
+            expect(sortCodePatterns(input, typeMembersConfig)).toBe(input);
+        });
+
+        it('should only skip the annotated block, not others', () => {
+            const input = `// @tidyjs-ignore-sort
+enum Ignored {
+    InProgress = 'in_progress',
+    OK = 'ok',
+}
+
+enum Sorted {
+    InProgress = 'in_progress',
+    OK = 'ok',
+}`;
+
+            const expected = `// @tidyjs-ignore-sort
+enum Ignored {
+    InProgress = 'in_progress',
+    OK = 'ok',
+}
+
+enum Sorted {
+    OK = 'ok',
+    InProgress = 'in_progress',
+}`;
+
+            expect(sortCodePatterns(input, enumConfig)).toBe(expected);
+        });
+
+        it('should handle extra whitespace in the directive', () => {
+            const input = `  //   @tidyjs-ignore-sort
+enum Status {
+    InProgress = 'in_progress',
+    OK = 'ok',
+}`;
+
+            expect(sortCodePatterns(input, enumConfig)).toBe(input);
+        });
+    });
+
+    describe('manual selection', () => {
+        it('should skip destructuring when preceded by @tidyjs-ignore-sort', () => {
+            const input = `// @tidyjs-ignore-sort
+const {
+    longName,
+    a,
+} = props;`;
+
+            expect(sortPropertiesInSelection(input, 0, input.length)).toBeNull();
+        });
+
+        it('should skip object literal when preceded by @tidyjs-ignore-sort', () => {
+            const input = `// @tidyjs-ignore-sort
+const obj = {
+    telephone: '123',
+    id: 1,
+    nom: 'test',
+};`;
+
+            expect(sortPropertiesInSelection(input, 0, input.length)).toBeNull();
+        });
+    });
+});
+
+describe('auto-skip enums with numeric initializers', () => {
+    it('should skip enum where all members have numeric initializers', () => {
+        const input = `enum ECurrentType {
+    Rubrique = 0,
+    EVP = 1,
+}`;
+
+        expect(sortCodePatterns(input, enumConfig)).toBe(input);
+    });
+
+    it('should skip enum with non-sequential numeric values', () => {
+        const input = `enum Flags {
+    Read = 4,
+    Write = 2,
+    Execute = 1,
+}`;
+
+        expect(sortCodePatterns(input, enumConfig)).toBe(input);
+    });
+
+    it('should still sort enum with string initializers', () => {
+        const input = `enum Status {
+    InProgress = 'in_progress',
+    OK = 'ok',
+    Error = 'error',
+}`;
+
+        const expected = `enum Status {
+    OK = 'ok',
+    Error = 'error',
+    InProgress = 'in_progress',
+}`;
+
+        expect(sortCodePatterns(input, enumConfig)).toBe(expected);
+    });
+
+    it('should still sort enum without initializers', () => {
+        const input = `enum Direction {
+    Southeast,
+    Up,
+    Down,
+}`;
+
+        const expected = `enum Direction {
+    Up,
+    Down,
+    Southeast,
+}`;
+
+        expect(sortCodePatterns(input, enumConfig)).toBe(expected);
+    });
+
+    it('should still sort enum with mixed initializer types', () => {
+        const input = `enum Mixed {
+    First = 0,
+    Second = 'two',
+    Third = 2,
+}`;
+
+        const result = sortCodePatterns(input, enumConfig);
+        expect(result).not.toBe(input);
+    });
+
+    it('should skip export const enum with numeric initializers', () => {
+        const input = `export const enum ECurrentType {
+    Rubrique = 0,
+    EVP = 1,
+}`;
+
+        expect(sortCodePatterns(input, enumConfig)).toBe(input);
     });
 });


### PR DESCRIPTION
## Summary
- Adds `// @tidyjs-ignore-sort` comment directive: place it on the line before any sortable block (enum, export, class, interface, type, destructuring, object) to prevent TidyJS from reordering its members. Works in both automatic and manual selection pipelines.
- Enums where **all** members have explicit numeric initializers (e.g. `A = 0, B = 1`) are now automatically skipped — the order is considered intentional/semantic.

## Motivation
When enums have numeric values, the order reflects business logic (e.g. `Rubrique = 0, EVP = 1`). Sorting them alphabetically or by length destroys that intent. The `@tidyjs-ignore-sort` directive provides a general escape hatch for any block where order matters.

## Test plan
- [x] 8 tests for `@tidyjs-ignore-sort` (enum, export, class, interface, type literal, scoped skip, whitespace tolerance, manual selection)
- [x] 6 tests for auto-skip numeric enums (all numeric, non-sequential, string values, no initializers, mixed types, export const enum)
- [x] Updated existing enum test with numeric values to reflect new behavior
- [x] All 851 tests pass, lint + type check clean